### PR TITLE
allow version numbers with hyphen; fix first tag issue

### DIFF
--- a/R/get_min_ver.R
+++ b/R/get_min_ver.R
@@ -125,6 +125,7 @@ get_min_ver.remote_ref_github <- function(remote_ref, op = "", op_ver = "") {
     return(remote_ref)
   }
 
+  ref_suffix <- ""
   if (op == "") {
     # loop from the earliest tag and check if a valid description file
     for (tag in tags) {
@@ -135,7 +136,6 @@ get_min_ver.remote_ref_github <- function(remote_ref, op = "", op_ver = "") {
     }
   } else {
     # loop from the earliest tag, check if valid description file and check against version prespecified
-    ref_suffix <- ""
     for (tag in tags) {
       tag_desc <- get_desc_from_gh(remote_ref$username, remote_ref$repo, tag)
       if ((length(tag_desc) == 1 && is.na(tag_desc)) || tag_desc$get_field("Package") != remote_ref$package) next

--- a/R/get_min_ver.R
+++ b/R/get_min_ver.R
@@ -88,11 +88,12 @@ get_min_ver.remote_ref_cran <- function(remote_ref, op = "", op_ver = "") {
 
   x_pkg_cache <- pkgcache::meta_cache_list(remote_ref$package)
   x_pkg_cache_archive <- pkgcache::cran_archive_list(package = remote_ref$package)
-  pv <- package_version(unique(c(x_pkg_cache$version, x_pkg_cache_archive$version)))
+  pv <- unique(c(x_pkg_cache_archive$version, x_pkg_cache$version))
+  pv <- setNames(package_version(pv), pv)
   pv <- filter_valid_version(pv, op, op_ver)
-  min_ver <- min(pv)
+  min_ver <- Filter(function(x) x == min(pv), pv)
 
-  new_ref <- sprintf("%s@%s", remote_ref$ref, min_ver) # @TODO deparse, add ver, parse again
+  new_ref <- sprintf("%s@%s", remote_ref$ref, names(min_ver)) # @TODO deparse, add ver, parse again
   pkgdepends::parse_pkg_ref(new_ref)
 }
 
@@ -125,12 +126,17 @@ get_min_ver.remote_ref_github <- function(remote_ref, op = "", op_ver = "") {
   }
 
   if (op == "") {
-    ref_suffix <- sprintf("@%s", tags[1])
+    # loop from the earliest tag and check if a valid description file
+    for (tag in tags) {
+      tag_desc <- get_desc_from_gh(remote_ref$username, remote_ref$repo, tag)
+      if ((length(tag_desc) == 1 && is.na(tag_desc)) || tag_desc$get_field("Package") != remote_ref$package) next
+      ref_suffix <- sprintf("@%s", tag)
+      break
+    }
   } else {
+    # loop from the earliest tag, check if valid description file and check against version prespecified
     ref_suffix <- ""
-    # it's needed to start from the end (i.e. latest tags) as there are many unexpected things in the history
-    # e.g. r-lib/styler decreased package version in the past
-    for (tag in rev(tags)) {
+    for (tag in tags) {
       tag_desc <- get_desc_from_gh(remote_ref$username, remote_ref$repo, tag)
       if ((length(tag_desc) == 1 && is.na(tag_desc)) || tag_desc$get_field("Package") != remote_ref$package) next
       tag_ver <- tag_desc$get_version()


### PR DESCRIPTION
- allow version number with hyphens, e.g. `1.2-3`
- add check if the first tag is a valid R package, to avoid e.g. `rstudio/shiny@rubyesque`