### PR TITLE
Fix tests by using `solve_ip(x)`

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -28,11 +28,14 @@ skip_if_empty_gh_token <- function() {
 #' the key
 #' @param remotes (`vector`) string vector that contains remotes to add to
 #' the DESCRIPTION file
+#' @param need_verdepcheck (`vector`) string vector that contains
+#' Config/Need/verdepcheck elements to add to the DESCRIPTION file
 #' @param .local_envir (`envirnoment`) The environment to use for scoping.
 #'
 #' @keywords internal
 local_description <- function(pkg_list = c(pkgdepends = "Import"),
                               remotes = c(),
+                              need_verdepcheck = c(),
                               .local_envir = parent.frame()) {
 
   d_std <- desc::desc("!new")
@@ -43,6 +46,10 @@ local_description <- function(pkg_list = c(pkgdepends = "Import"),
 
   for (remote in remotes) {
     d_std$add_remotes(remote)
+  }
+
+  if (!is.null(verdepcheck) && length(verdepcheck) > 0) {
+    d_std$set("Config/Needs/verdepcheck", paste(need_verdepcheck, collapse = ","))
   }
 
   path <- tempfile(pattern = "DESCRIPTION")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,6 +1,6 @@
 skip_if_offline <- function() {
   res <- tryCatch(
-    pingr::ping("https://api.github.com", count = 1L),
+    pingr::ping("api.github.com", count = 1L),
     error = function(e) NA
   )
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,4 +1,7 @@
 skip_if_offline <- function() {
+  if (!requireNamespace("pingr", quietly = TRUE)) {
+    skip("`pingr` cannot be loaded, can't test internet connection.")
+  }
   res <- tryCatch(
     pingr::ping("api.github.com", count = 1L),
     error = function(e) NA
@@ -14,4 +17,61 @@ skip_if_empty_gh_token <- function() {
   )
 
   if (isFALSE(res)) skip("Not run with empty GH token")
+}
+
+local_description <- function(pkg_list = list(pkgdepends = "Import"),
+                              remotes = list(),
+                              .local_envir = parent.frame()) {
+
+  d_std <- desc::desc("!new")
+
+  for (pkg in names(pkg_list)) {
+    d_std$set_dep(pkg, pkg_list[[pkg]])
+  }
+
+  for (remote in remotes) {
+    d_std$add_remotes(remote)
+  }
+
+  path <- tempfile(pattern = "DESCRIPTION")
+  d_std$write(path)
+  withr::defer(unlink(path), envir = .local_envir)
+
+  path
+}
+
+test_proposal_common <- function(x,
+                                 pkg_name = "pkgdepends",
+                                 platform = "source",
+                                 pkg_ver_target = NULL) {
+  expect_s3_class(x, "pkg_installation_proposal")
+
+  solve_ip(x)
+
+  expect_equal(x$get_solution()$status, "OK")
+
+  x_solution <- x$get_resolution()
+
+  x_solution_pkg <- subset(
+    x_solution,
+    package == pkg_name & platform == "source" & repotype == "cran"
+  )
+
+  expect_equal(nrow(x_solution_pkg), 1)
+
+  pkg_ver_act <- package_version(x_solution_pkg$version)
+
+  # If there is no specific version to check, then compare against latest from
+  #  CRAN
+  if (is.null(pkg_ver_target)) {
+    pkg_ver_target <- package_version(
+      available.packages(
+        repos = pkgcache::default_cran_mirror(),
+        filters = list(add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ])
+      )[["Version"]]
+    )
+  }
+
+  expect_identical(pkg_ver_act, package_version(pkg_ver_target))
+  invisible(x)
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,4 +1,6 @@
 skip_if_offline <- function() {
+  # Using this conditional clause instead of `skip_if_not_installed` to provide
+  #  a better message
   if (!requireNamespace("pingr", quietly = TRUE)) {
     skip("`pingr` cannot be loaded, can't test internet connection.")
   }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -19,8 +19,20 @@ skip_if_empty_gh_token <- function() {
   if (isFALSE(res)) skip("Not run with empty GH token")
 }
 
-local_description <- function(pkg_list = list(pkgdepends = "Import"),
-                              remotes = list(),
+#' Temporarily create a valid DESCRIPTION file to a temporary location
+#'
+#' The file is deleted after the parent function where this function was called
+#' has exited, when the R session ends or on deman via [withr::deferred_run()]
+#' @param pkg_list (`vector`) named character vector or list with
+#' paired name and type of dependency. It supports versions by using quotes on
+#' the key
+#' @param remotes (`vector`) string vector that contains remotes to add to
+#' the DESCRIPTION file
+#' @param .local_envir (`envirnoment`) The environment to use for scoping.
+#'
+#' @keywords internal
+local_description <- function(pkg_list = c(pkgdepends = "Import"),
+                              remotes = c(),
                               .local_envir = parent.frame()) {
 
   d_std <- desc::desc("!new")
@@ -40,6 +52,22 @@ local_description <- function(pkg_list = list(pkgdepends = "Import"),
   path
 }
 
+#' Aggregator of tests to generally perform on proposals
+#'
+#' @param x (`pkg_installation_proposal` object) Valid proposal created by one
+#' of the available methods.
+#' @param pkg_name (`string`) Name of package that is being tested for version.
+#' @param platform (optional `string`) Name of the platform, should be 'source' in
+#' most cases.
+#' @param pkg_ver_target (optional `string`) version that is expected to be in the
+#' proposal. A `NULL` value indicates to use the latest version on CRAN or a
+#' GitHub repository reference
+#' @param pkg_gh_str (optional `string`) GitHub repository reference to retrieve
+#' the version that is on the main branch. When both this parameter and
+#' `pkg_ver_target` are `NULL`, then it will compare the version in the proposal
+#' with the latest version in CRAN.
+#'
+#' @keywords internal
 test_proposal_common <- function(x,
                                  pkg_name = "pkgdepends",
                                  platform = "source",

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -43,7 +43,8 @@ local_description <- function(pkg_list = list(pkgdepends = "Import"),
 test_proposal_common <- function(x,
                                  pkg_name = "pkgdepends",
                                  platform = "source",
-                                 pkg_ver_target = NULL) {
+                                 pkg_ver_target = NULL,
+                                 pkg_gh_str = NULL) {
   expect_s3_class(x, "pkg_installation_proposal")
 
   solve_ip(x)
@@ -63,13 +64,20 @@ test_proposal_common <- function(x,
 
   # If there is no specific version to check, then compare against latest from
   #  CRAN
-  if (is.null(pkg_ver_target)) {
+  if (is.null(pkg_gh_str) && is.null(pkg_ver_target)) {
     pkg_ver_target <- package_version(
       available.packages(
         repos = pkgcache::default_cran_mirror(),
-        filters = list(add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ])
+        filters = list(
+          add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ]
+        )
       )[["Version"]]
     )
+  } else if (!is.null(pkg_gh_str) && is.null(pkg_ver_target)) {
+    gh_str_split <- strsplit(pkg_gh_str, "/")[[1]]
+    pkg_ver_target <- package_version(as.character(
+      get_desc_from_gh(gh_str_split[1], gh_str_split[2])$get_version()
+    ))
   }
 
   expect_identical(pkg_ver_act, package_version(pkg_ver_target))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -50,7 +50,7 @@ local_description <- function(pkg_list = c(pkgdepends = "Import"),
     d_std$add_remotes(remote)
   }
 
-  if (!is.null(verdepcheck) && length(verdepcheck) > 0) {
+  if (!is.null(need_verdepcheck) && length(need_verdepcheck) > 0) {
     d_std$set(.desc_field, paste(need_verdepcheck, collapse = ", "))
   }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -51,7 +51,7 @@ local_description <- function(pkg_list = c(pkgdepends = "Import"),
   }
 
   if (!is.null(verdepcheck) && length(verdepcheck) > 0) {
-    d_std$set("Config/Needs/verdepcheck", paste(need_verdepcheck, collapse = ","))
+    d_std$set(.desc_field, paste(need_verdepcheck, collapse = ", "))
   }
 
   path <- tempfile(pattern = "DESCRIPTION")

--- a/tests/testthat/test-deps_installation_proposal.R
+++ b/tests/testthat/test-deps_installation_proposal.R
@@ -6,7 +6,7 @@ test_that("new_max_deps_installation_proposal correctly handles standard referen
   x <- new_max_deps_installation_proposal(d_std_path)
   withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source")
+  test_proposal_common(x, "pkgdepends", "source", NULL, NULL)
 })
 
 test_that("new_release_deps_installation_proposal correctly handles standard reference", {
@@ -18,7 +18,7 @@ test_that("new_release_deps_installation_proposal correctly handles standard ref
 
   withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source")
+  test_proposal_common(x, "pkgdepends", "source", NULL, NULL)
 })
 
 test_that("new_min_isolated_installation_proposal correctly handles standard reference", {
@@ -29,10 +29,10 @@ test_that("new_min_isolated_installation_proposal correctly handles standard ref
   x <- new_min_isolated_deps_installation_proposal(d_std_path)
   withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source", "0.1.0")
+  test_proposal_common(x, "pkgdepends", "source", "0.1.0", NULL)
 })
 
-test_that("new_min_cohort_installation_proposal correctly handles standard reference", {
+test_that("new_min_cohort_deps_installation_proposal correctly handles standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
@@ -40,7 +40,7 @@ test_that("new_min_cohort_installation_proposal correctly handles standard refer
   x <- new_min_cohort_deps_installation_proposal(d_std_path)
   withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source", "0.1.0")
+  test_proposal_common(x, "pkgdepends", "source", "0.1.0", NULL)
 })
 
 # #################################################################
@@ -62,13 +62,9 @@ test_that("new_max_deps_installation_proposal correctly handles <org>/<repo> ref
   skip_if_empty_gh_token()
 
   remote_str <- "r-lib/pkgdepends"
-
-  d_std_path <- local_description(
-    list(pkgdepends = "Import"), remotes = c(remote_str)
-  )
+  d_std_path <- local_description(list(pkgdepends = "Import"), remotes = c(remote_str))
   x <- new_max_deps_installation_proposal(d_std_path)
   withr::defer(unlink(x$get_config()$library))
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
 
   test_proposal_common(x, "pkgdepends", "source", NULL, remote_str)
 })
@@ -77,50 +73,36 @@ test_that("new_release_deps_installation_proposal correctly handles <org>/<repo>
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_release_deps_installation_proposal(ref_gh_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  remote_str <- "r-lib/pkgdepends"
+  d_std_path <- local_description(list(pkgdepends = "Import"), remotes = c(remote_str))
+  x <- new_release_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  expect_s3_class(x, "pkg_installation_proposal")
+  test_proposal_common(x, "pkgdepends", "source", NULL, NULL)
+})
 
-  x$solve()
-  expect_equal(x$get_solution()$status, "OK")
+test_that("new_min_cohort_deps_installation_proposal correctly handles <org>/<repo> reference", {
+  skip_if_offline()
+  skip_if_empty_gh_token()
 
-  x_solution <- x$get_resolution()
+  remote_str <- "r-lib/pkgdepends"
+  d_std_path <- local_description(list(pkgdepends = "Import"), remotes = c(remote_str))
+  x <- new_min_cohort_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version(
-    available.packages(
-      repos = pkgcache::default_cran_mirror(),
-      filters = list(add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ])
-    )[["Version"]]
-  )
-  expect_equal(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
 })
 
 test_that("new_min_deps_installation_proposal correctly handles <org>/<repo> reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_min_deps_installation_proposal(ref_gh_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  remote_str <- "r-lib/pkgdepends"
+  d_std_path <- local_description(list(pkgdepends = "Import"), remotes = c(remote_str))
+  x <- new_min_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  expect_s3_class(x, "pkg_installation_proposal")
-
-  x$solve()
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version("0.1.0")
-
-  expect_identical(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
 })
 
 # ################################################################
@@ -137,22 +119,18 @@ test_that("new_min_deps_installation_proposal correctly handles <org>/<repo> ref
 #  with (>= a.b.c)
 # ###############################################################
 
-test_that("new_min_deps_installation_proposal correctly handles \">=\" dependency for <org>/<repo> reference", {
+test_that("new_min_isolated_deps_installation_proposal correctly handles \">=\" dependency for <org>/<repo> reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  d_std_path <- local_description(
-    list(`pkgdepends (>= 0.2.0)` = "Import"), "r-lib/pkgdepends"
-  )
+  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"), "r-lib/pkgdepends")
   x <- new_min_isolated_deps_installation_proposal(d_std_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
-
-  expect_s3_class(x, "pkg_installation_proposal")
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
 })
 
-test_that("new_min_deps_installation_proposal correctly handles \">=\" dependency for standard reference", {
+test_that("new_min_isolated_deps_installation_proposal correctly handles \">=\" dependency for standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
@@ -160,5 +138,27 @@ test_that("new_min_deps_installation_proposal correctly handles \">=\" dependenc
   x <- new_min_isolated_deps_installation_proposal(d_std_path)
   withr::defer(unlink(x$get_config()$library))
 
-  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
+})
+
+test_that("new_min_cohort_deps_installation_proposal correctly handles \">=\" dependency for <org>/<repo> reference", {
+  skip_if_offline()
+  skip_if_empty_gh_token()
+
+  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"), "r-lib/pkgdepends")
+  x <- new_min_cohort_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
+
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
+})
+
+test_that("new_min_cohort_deps_installation_proposal correctly handles \">=\" dependency for standard reference", {
+  skip_if_offline()
+  skip_if_empty_gh_token()
+
+  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"))
+  x <- new_min_cohort_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
+
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0", NULL)
 })

--- a/tests/testthat/test-deps_installation_proposal.R
+++ b/tests/testthat/test-deps_installation_proposal.R
@@ -32,17 +32,6 @@ test_that("new_min_isolated_installation_proposal correctly handles standard ref
   test_proposal_common(x, "pkgdepends", "source", "0.1.0")
 })
 
-test_that("new_min_isolated_installation_proposal correctly handles standard reference", {
-  skip_if_offline()
-  skip_if_empty_gh_token()
-
-  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"))
-  x <- new_min_isolated_deps_installation_proposal(d_std_path)
-  withr::defer(unlink(x$get_config()$library))
-
-  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
-})
-
 test_that("new_min_cohort_installation_proposal correctly handles standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
@@ -54,35 +43,34 @@ test_that("new_min_cohort_installation_proposal correctly handles standard refer
   test_proposal_common(x, "pkgdepends", "source", "0.1.0")
 })
 
-####
-
-d_gh <- desc::desc("!new")
-d_gh$set_dep("pkgdepends", "Import")
-d_gh$add_remotes("r-lib/pkgdepends")
-ref_gh_path <- tempfile()
-d_gh$write(ref_gh_path)
-on.exit(unlink(ref_gh_path), add = TRUE, after = FALSE)
+# #################################################################
+#
+#            _ _   _                                _
+#           (_) | | |                              | |
+#  __      ___| |_| |__    _ __ ___ _ __ ___   ___ | |_ ___  ___
+#  \ \ /\ / / | __| '_ \  | '__/ _ \ '_ ` _ \ / _ \| __/ _ \/ __|
+#   \ V  V /| | |_| | | | | | |  __/ | | | | | (_) | ||  __/\__ \
+#    \_/\_/ |_|\__|_| |_| |_|  \___|_| |_| |_|\___/ \__\___||___/
+#
+#
+#
+#  with remotes
+# ################################################################
 
 test_that("new_max_deps_installation_proposal correctly handles <org>/<repo> reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_max_deps_installation_proposal(ref_gh_path)
+  remote_str <- "r-lib/pkgdepends"
+
+  d_std_path <- local_description(
+    list(pkgdepends = "Import"), remotes = c(remote_str)
+  )
+  x <- new_max_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
   on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
 
-  expect_s3_class(x, "pkg_installation_proposal")
-
-  x$solve()
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version(as.character(get_desc_from_gh("r-lib", "pkgdepends")$get_version()))
-  expect_equal(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source", NULL, remote_str)
 })
 
 test_that("new_release_deps_installation_proposal correctly handles <org>/<repo> reference", {
@@ -135,61 +123,42 @@ test_that("new_min_deps_installation_proposal correctly handles <org>/<repo> ref
   expect_identical(pkg_ver_act, pkg_ver_target)
 })
 
-####
+# ################################################################
+#
+#            _ _   _        ____                   _        __
+#           (_) | | |      / /\ \ ______          | |       \ \
+#  __      ___| |_| |__   | |  \ \______|   __ _  | |__   ___| |
+#  \ \ /\ / / | __| '_ \  | |   > >_____   / _` | | '_ \ / __| |
+#   \ V  V /| | |_| | | | | |  / /______| | (_| |_| |_) | (__| |
+#    \_/\_/ |_|\__|_| |_| | | /_/          \__,_(_)_.__(_)___| |
+#                          \_\                              /_/
+#
+#
+#  with (>= a.b.c)
+# ###############################################################
 
 test_that("new_min_deps_installation_proposal correctly handles \">=\" dependency for <org>/<repo> reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  temp_path <- tempfile()
-  d <- desc::desc("!new")
-  d$set_dep("pkgdepends", "Import", ">= 0.2.0")
-  d$add_remotes("r-lib/pkgdepends")
-  d$write(temp_path)
-  on.exit(unlink(temp_path), add = TRUE, after = FALSE)
-
-  x <- new_min_deps_installation_proposal(temp_path)
+  d_std_path <- local_description(
+    list(`pkgdepends (>= 0.2.0)` = "Import"), "r-lib/pkgdepends"
+  )
+  x <- new_min_isolated_deps_installation_proposal(d_std_path)
   on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
 
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
+
   expect_s3_class(x, "pkg_installation_proposal")
-
-  x$solve()
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version("0.2.0")
-  expect_identical(pkg_ver_act, pkg_ver_target)
 })
 
 test_that("new_min_deps_installation_proposal correctly handles \">=\" dependency for standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  temp_path <- tempfile()
-  d <- desc::desc("!new")
-  d$set_dep("pkgdepends", "Import", ">= 0.2.0")
-  d$write(temp_path)
-  on.exit(unlink(temp_path), add = TRUE, after = FALSE)
+  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"))
+  x <- new_min_isolated_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  x <- new_min_deps_installation_proposal(temp_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
-
-  expect_s3_class(x, "pkg_installation_proposal")
-
-  x$solve()
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version("0.2.0")
-  expect_identical(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
 })

--- a/tests/testthat/test-deps_installation_proposal.R
+++ b/tests/testthat/test-deps_installation_proposal.R
@@ -1,87 +1,57 @@
-d_std <- desc::desc("!new")
-d_std$set_dep("pkgdepends", "Import")
-ref_std_path <- tempfile()
-d_std$write(ref_std_path)
-on.exit(unlink(ref_std_path), add = TRUE, after = FALSE)
-
 test_that("new_max_deps_installation_proposal correctly handles standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_max_deps_installation_proposal(ref_std_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  d_std_path <- local_description(list(pkgdepends = "Import"))
+  x <- new_max_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  expect_s3_class(x, "pkg_installation_proposal")
-
-  x$solve()
-
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version(
-    available.packages(
-      repos = pkgcache::default_cran_mirror(),
-      filters = list(add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ])
-    )[["Version"]]
-  )
-  expect_identical(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source")
 })
 
 test_that("new_release_deps_installation_proposal correctly handles standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_release_deps_installation_proposal(ref_std_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  d_std_path <- local_description(list(pkgdepends = "Import"))
+  x <- new_release_deps_installation_proposal(d_std_path)
 
-  expect_s3_class(x, "pkg_installation_proposal")
+  withr::defer(unlink(x$get_config()$library))
 
-  x$solve()
-
-  expect_equal(x$get_solution()$status, "OK")
-
-  x_solution <- x$get_resolution()
-
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
-
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version(
-    available.packages(
-      repos = pkgcache::default_cran_mirror(),
-      filters = list(add = TRUE, function(x) x[x[, "Package"] == "pkgdepends", ])
-    )[["Version"]]
-  )
-  expect_identical(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source")
 })
 
-test_that("new_min_deps_installation_proposal correctly handles standard reference", {
+test_that("new_min_isolated_installation_proposal correctly handles standard reference", {
   skip_if_offline()
   skip_if_empty_gh_token()
 
-  x <- new_min_deps_installation_proposal(ref_std_path)
-  on.exit(unlink(x$get_config()$library), add = TRUE, after = FALSE)
+  d_std_path <- local_description(list(pkgdepends = "Import"))
+  x <- new_min_isolated_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  expect_s3_class(x, "pkg_installation_proposal")
+  test_proposal_common(x, "pkgdepends", "source", "0.1.0")
+})
 
-  x$solve()
+test_that("new_min_isolated_installation_proposal correctly handles standard reference", {
+  skip_if_offline()
+  skip_if_empty_gh_token()
 
-  expect_equal(x$get_solution()$status, "OK")
+  d_std_path <- local_description(list(`pkgdepends (>= 0.2.0)` = "Import"))
+  x <- new_min_isolated_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  x_solution <- x$get_resolution()
+  test_proposal_common(x, "pkgdepends", "source", "0.2.0")
+})
 
-  x_solution_pkg <- subset(x_solution, package == "pkgdepends" & platform == "source")
-  expect_equal(nrow(x_solution_pkg), 1)
+test_that("new_min_cohort_installation_proposal correctly handles standard reference", {
+  skip_if_offline()
+  skip_if_empty_gh_token()
 
-  pkg_ver_act <- package_version(x_solution_pkg$version)
-  pkg_ver_target <- package_version("0.1.0")
+  d_std_path <- local_description(list(pkgdepends = "Import"))
+  x <- new_min_cohort_deps_installation_proposal(d_std_path)
+  withr::defer(unlink(x$get_config()$library))
 
-  expect_identical(pkg_ver_act, pkg_ver_target)
+  test_proposal_common(x, "pkgdepends", "source", "0.1.0")
 })
 
 ####


### PR DESCRIPTION
### Motivation

I was thinking on a way to test some of the changes I've been making and realized that tests were outdated.

None of the tests were passing, I corrected them and simplified the code to remove repetitive lines that are difficult to support.

_note_: this PR is not included in the other one to avoid having 1 big PR.

### Current status

Not all of the tests currently pass (pre or post-simplification), but it might be the `Remotes` bug you mentioned or something else that I need to correct.

Regardless these tests should be correct.

### Changes description

* Tests was very outdated with `x$solve()` being used instead of `solve_ip()`
* Adds `local_description()` helper
  * Uses `{withr::local_*}` logic to create a temporary DESCRIPTION file and then remove from disk
  * Supports adding an arbitrary number of imports
  * Supports adding an arbitrary number of remotes
* Adds `test_proposal_common()` helper
  * Avoids having repetitive code for what is essentially the same testing logic.
  * The function has a bit of complexity but cleans up the tests very well
* Style: adds an ASCII separator between test sections
  * [figlet](http://www.figlet.org/) uses a modified figlet script

@pawelru would you prefer to have your branch as the base?