### PR TITLE
Fix random download of source tarball instead of binary

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -105,6 +105,22 @@ execute_ip <- function(ip, path, build_args, check_args, ...) {
 #'
 #' @export
 download_ip <- function(ip) {
+  res <- ip$get_resolution()
+
+  # Prevent downloads of non-binary files by removing source that has "Archive" in the URL
+  ix <- res$platform == pkgdepends::current_r_platform()
+  new_sources <- lapply(
+    res$sources[ix],
+    function(x) {
+      if (length(x) > 1 && any(grepl("src/contrib/Archive", x))) {
+        x[!grepl("src/contrib/Archive", x)]
+      } else {
+        x
+      }
+    }
+  )
+  ip$.__enclos_env__$private$plan$.__enclos_env__$private$resolution$result$sources[ix] <- new_sources
+
   ip$download()
   ip$stop_for_download_error()
 

--- a/R/check.R
+++ b/R/check.R
@@ -139,6 +139,7 @@ download_ip <- function(ip) {
           pkgdepends:::verify_extracted_package(res$package[ix_el], "./")
         }, error = function(error) {
           cli::cli_warn("{res$package[ix_el]} binary is not valid, trying to re-download.")
+          print(res[ix_el, ])
           cli::cli_warn(error)
           # Attempts to download again using curl::curl_download
           async_fun <- asNamespace("pkgcache")$async(function() {

--- a/R/get_ref.R
+++ b/R/get_ref.R
@@ -451,9 +451,9 @@ get_release_date.remote_ref_cran <- function(remote_ref) {
         package_version(remote_ref$version, strict = FALSE)
       )
     )
-    as.Date(tail(rel_data[idx, "mtime"], 1))
+    as.Date(utils::tail(rel_data[idx, "mtime"], 1))
   } else {
-    as.Date(tail(rel_data$mtime, 1))
+    as.Date(utils::tail(rel_data$mtime, 1))
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ default_config <- function() {
   )
 }
 append_config <- function(x1, x2) {
-  modifyList(x1, x2)
+  utils::modifyList(x1, x2)
 }
 
 #' @importFrom utils installed.packages

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The main functions are:
 - `new_<strategy>_deps_installation_proposal` for creating `installation_proposal` objects
 - `<strategy>_deps_check` that creates and executes `installation_proposal` and then run `"R CMD CHECK"`
 
-This package is heavily based on [`pkgdepends`](https://r-lib.github.io/pkgdepends/) for dependency resolution and [`rcmdcheck`](https://r-lib.github.io/rcmdcheck/) for executing `"R CMD CHECK"`.
+This package is heavily based on [`pkgdepends`](https://r-lib.github.io/pkgdepends/) for dependency resolution and [`rcmdcheck`](https://rcmdcheck.r-lib.org/) for executing `"R CMD CHECK"`.
 
 ## Install
 


### PR DESCRIPTION
# Pull Request

- Closes #44 

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Upstream bug: https://github.com/r-lib/pkgdepends/issues/367

#### Changes description:

- Removes sources links that include "src/contrib/Archive"
  - When `{pkgdepends}` attempts to download the tarball, it will try all sources and archive-based sources are only source-code
- Re-downloads tarball using mirror.
  - Last attempt to explicitly use `ppm` snapshot mirror

#### Testing

1. Install or load this branch
    - `renv::install("insightsengineering/verdepcheck@fix-random-download%40main")`
3. Clone [`{tmc}`](https://github.com/insightsengineering/teal.modules.clinical)
    - checkout `546-fix-verdepcheck@main` branch
5. Run all strategies:
    - `verdepcheck::min_cohort_deps_check("/path/to/tmc")`
    - `verdepcheck::min_isolated_deps_check("/path/to/tmc")`
    - `verdepcheck::release_deps_check("/path/to/tmc")`
    - `verdepcheck::max_deps_check("/path/to/tmc")`