### PR TITLE
include refs for indirect deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3

--- a/R/deps_installation_proposal.R
+++ b/R/deps_installation_proposal.R
@@ -63,6 +63,7 @@ new_max_deps_installation_proposal <- function(path, # nolint
   config <- append_config(default_config(), config)
 
   d <- desc::desc(path)
+  d <- desc_add_extra_deps(d, extra_deps)
 
   refs <- get_refs_from_desc(d)
   new_refs <- list()
@@ -75,7 +76,6 @@ new_max_deps_installation_proposal <- function(path, # nolint
   new_refs_str <- map_key_character(new_refs, "ref")
 
   d <- desc_cond_set_refs(d, new_refs_str)
-  d <- desc_add_extra_deps(d, extra_deps)
 
   res <- desc_to_ip(d, config)
   class(res) <- c("max_deps_installation_proposal", "deps_installation_proposal", class(res))
@@ -96,6 +96,7 @@ new_release_deps_installation_proposal <- function(path, # nolint
   config <- append_config(default_config(), config)
 
   d <- desc::desc(path)
+  d <- desc_add_extra_deps(d, extra_deps)
 
   refs <- get_refs_from_desc(d)
   new_refs <- list()
@@ -108,7 +109,6 @@ new_release_deps_installation_proposal <- function(path, # nolint
   new_refs_str <- map_key_character(new_refs, "ref")
 
   d <- desc_cond_set_refs(d, new_refs_str)
-  d <- desc_add_extra_deps(d, extra_deps)
   d <- desc_remotes_cleanup(d)
 
   res <- desc_to_ip(d, config)
@@ -131,6 +131,7 @@ new_min_cohort_deps_installation_proposal <- function(path, # nolint
   config <- append_config(default_config(), config)
 
   d <- desc::desc(path)
+  d <- desc_add_extra_deps(d, extra_deps)
 
   refs <- get_refs_from_desc(d)
   # convert github to standard if possible
@@ -163,7 +164,6 @@ new_min_cohort_deps_installation_proposal <- function(path, # nolint
   )
   new_refs_str <- map_key_character(new_refs, "ref")
   d <- desc_cond_set_refs(d, new_refs_str)
-  d <- desc_add_extra_deps(d, extra_deps)
   d <- desc_remotes_cleanup(d)
 
   # find PPM snapshot
@@ -237,6 +237,7 @@ new_min_isolated_deps_installation_proposal <- function(path, # nolint
   config <- append_config(default_config(), config)
 
   d <- desc::desc(path)
+  d <- desc_add_extra_deps(d, extra_deps)
 
   refs <- get_refs_from_desc(d)
 
@@ -272,7 +273,6 @@ new_min_isolated_deps_installation_proposal <- function(path, # nolint
   new_refs_str <- map_key_character(new_refs, "ref")
 
   d <- desc_cond_set_refs(d, new_refs_str)
-  d <- desc_add_extra_deps(d, extra_deps)
   d <- desc_remotes_cleanup(d)
 
   res <- desc_to_ip(d, config)

--- a/tests/testthat/test-deps_installation_proposal.R
+++ b/tests/testthat/test-deps_installation_proposal.R
@@ -347,7 +347,7 @@ test_that("indirect dependencies in the config field - ignore on default", {
   withr::defer(unlink(x$get_config()$library))
 
   d_new <- desc::desc(gsub("^deps::", "", x$get_refs()))
-  expect_false("r-lib/rlang" %in% d_new$get_field("Config/Needs/verdepcheck"))
+  expect_false("r-lib/rlang" %in% d_new$get_list("Config/Needs/verdepcheck"))
 })
 
 test_that("indirect dependencies in the config field - include on match with `extra_deps`", {
@@ -360,5 +360,5 @@ test_that("indirect dependencies in the config field - include on match with `ex
   withr::defer(unlink(x$get_config()$library))
 
   d_new <- desc::desc(gsub("^deps::", "", x$get_refs()))
-  expect_false("r-lib/rlang" %in% d_new$get_field("Config/Needs/verdepcheck"))
+  expect_true("r-lib/rlang" %in% d_new$get_list("Config/Needs/verdepcheck"))
 })

--- a/tests/testthat/test-deps_installation_proposal.R
+++ b/tests/testthat/test-deps_installation_proposal.R
@@ -334,3 +334,31 @@ test_that("new_max_deps_installation_proposal correctly handles Bioc package", {
 
   test_proposal_common_bioc(x, "SummarizedExperiment")
 })
+
+# ################################################################
+
+test_that("indirect dependencies in the config field - ignore on default", {
+  skip_if_offline()
+
+  d_std_path <- local_description(list(dplyr = "Import"), need_verdepcheck = c("tidyverse/dplyr", "r-lib/rlang"))
+
+  x <- new_max_deps_installation_proposal(d_std_path)
+
+  withr::defer(unlink(x$get_config()$library))
+
+  d_new <- desc::desc(gsub("^deps::", "", x$get_refs()))
+  expect_false("r-lib/rlang" %in% d_new$get_field("Config/Needs/verdepcheck"))
+})
+
+test_that("indirect dependencies in the config field - include on match with `extra_deps`", {
+  skip_if_offline()
+
+  d_std_path <- local_description(list(dplyr = "Import"), need_verdepcheck = c("tidyverse/dplyr", "r-lib/rlang"))
+
+  x <- new_max_deps_installation_proposal(d_std_path, extra_deps = "rlang")
+
+  withr::defer(unlink(x$get_config()$library))
+
+  d_new <- desc::desc(gsub("^deps::", "", x$get_refs()))
+  expect_false("r-lib/rlang" %in% d_new$get_field("Config/Needs/verdepcheck"))
+})


### PR DESCRIPTION
this fixes the issue observed when testing on `teal@479_mirai_pr`
`mirai@main` requires dev version of `nanonext`. We recently added `extra_deps` parameter to be able to include this in the Imports but we also need to use `Config/Needs/verdepcheck` entry for these extra dependencies. Right now all additional entries are dropped in `get_refs_from_desc()`. The change is pretty simple - add extra deps before this function call.