### PR TITLE
Update temporary DESCRIPTION file handling in desc_to_ip function

### DIFF
--- a/R/desc_utils.R
+++ b/R/desc_utils.R
@@ -205,12 +205,16 @@ deparse_ver_str <- function(x) {
 #' @importFrom pkgdepends new_pkg_installation_proposal
 #' @keywords internal
 desc_to_ip <- function(d, config) {
-  temp_desc <- tempfile()
-  d$write(temp_desc)
-  cli::cli_alert_info(paste0("Creating temporary DESCRIPTION file: ", cli::col_blue(temp_desc)))
+  temp_dir <- tempfile()
+  dir.create(temp_dir)
 
+  d$write(file.path(temp_dir, "DESCRIPTION"))
+
+  cli::cli_alert_info(paste0("Creating temporary package directory: ", cli::col_blue(temp_dir)))
+
+  # Use the directory path with deps::
   pkgdepends::new_pkg_installation_proposal(
-    refs = paste0("deps::", temp_desc),
+    refs = paste0("deps::", temp_dir),
     config = config
   )
 }

--- a/R/desc_utils.R
+++ b/R/desc_utils.R
@@ -119,7 +119,7 @@ desc_cond_set_refs <- function(d, refs) {
   } else {
     d$del(.desc_field)
   }
-  return(invisible(d))
+  invisible(d)
 }
 
 #' Adds extra dependencies to the `desc` object.
@@ -150,7 +150,7 @@ desc_add_extra_deps <- function(d, x) {
       d$set_dep(x_i_deparsed$package, "Imports", x_i_deparsed$ver_str)
     }
   }
-  return(invisible(d))
+  invisible(d)
 }
 
 #' Deparse a dependency string


### PR DESCRIPTION
This is due to the new release of `pkgdepends` which brakes the following: `pkgdepends::new_pkg_deps("deps::/path/to/pkg/DESCRIPTION")`. It has to be changed to `pkgdepends::new_pkg_deps("deps::/path/to/pkg")`. I wouldn't call it a bug - it's probably non documented and not planned feature that we have used.